### PR TITLE
Set message identifier on subscription events

### DIFF
--- a/Sources/ActionCableSwift/ACSerializer.swift
+++ b/Sources/ActionCableSwift/ACSerializer.swift
@@ -40,11 +40,18 @@ public class ACSerializer {
         guard
             let dict = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
             else { fatalError(ACError.badDictionaryData.description) }
-
+        
         let messageType = checkResponseType(dict)
         switch messageType {
-        case .confirmSubscription, .rejectSubscription, .cancelSubscription, .hibernateSubscription:
-            return ACMessage(type: messageType)
+        case .confirmSubscription,
+                .rejectSubscription,
+                .cancelSubscription,
+                .hibernateSubscription:
+            var message = ACMessage(type: messageType)
+            if let identifier = dict["identifier"] as? String {
+                message.identifier = identifier.toDictionary()
+            }
+            return message
         case .welcome, .ping:
             return ACMessage(type: messageType)
         case .message, .unrecognized:


### PR DESCRIPTION
This change sets the `message.identifier` on subscription events.
Otherwise the `isSubscribed` is always `false` in `ACChannel`

Specifically this check is always false since `message.channel` is nil 
`guard message.channelName == self.channelName else { return }`