### PR TITLE
Fixed channel identifier check for type ping

### DIFF
--- a/Sources/ActionCableSwift/ACChannel.swift
+++ b/Sources/ActionCableSwift/ACChannel.swift
@@ -170,21 +170,21 @@ public class ACChannel {
             guard let self = self else { return }
             self.channelSerialQueue.async {
                 let message = ACSerializer.responseFrom(stringData: text)
-                guard message.channelName == self.channelName else { return }
-                switch message.type {
-                case .confirmSubscription:
+                let sameChannelName = message.channelName == self.channelName
+                switch (message.type, sameChannelName) {
+                case (.confirmSubscription, true):
                     self.isSubscribed = true
                     self.executeCallback(callbacks: self.onSubscribe, message: message)
                     self.flushBuffer()
-                case .rejectSubscription:
+                case (.rejectSubscription, true):
                     self.isSubscribed = false
                     self.executeCallback(callbacks: self.onRejectSubscription, message: message)
-                case .cancelSubscription:
+                case (.cancelSubscription, true):
                     self.isSubscribed = false
                     self.executeCallback(callbacks: self.onUnsubscribe, message: message)
-                case .message:
+                case (.message, true):
                     self.executeCallback(callbacks: self.onMessage, message: message)
-                case .ping:
+                case (.ping, _):
                     self.client?.pingRoundWatcher.ping()
                     self.executeCallback(callbacks: self.onPing)
                 default: break


### PR DESCRIPTION
Based on the description of the **ActionCable** protocol, a message with the "ping" type comes without a channel identifier. The fix allows for each type of message to specify whether it is necessary to look at the channel identifier.

https://docs.anycable.io/misc/action_cable_protocol

> Server sends ping messages ({ "type": "ping", "message": <Time.now.to_i>})